### PR TITLE
[Wasm Exceptions] Fix a handwritten exceptions test (#3639)

### DIFF
--- a/test/passes/code-pushing_all-features.txt
+++ b/test/passes/code-pushing_all-features.txt
@@ -50,9 +50,7 @@
      )
     )
     (catch_all
-     (drop
-      (pop i32)
-     )
+     (nop)
     )
    )
    (drop

--- a/test/passes/code-pushing_all-features.wast
+++ b/test/passes/code-pushing_all-features.wast
@@ -35,9 +35,7 @@
         (do
           (throw $e (i32.const 0))
         )
-        (catch_all
-          (drop (pop i32))
-        )
+        (catch_all)
       )
       (drop (i32.const 1))
       (br_if $out (i32.const 2))


### PR DESCRIPTION
catch_all should not have a pop.