### PR TITLE
[Optimize Instructions] Combine reinterprets, loads and stores (#4006)

### DIFF
--- a/src/ir/abstract.h
+++ b/src/ir/abstract.h
@@ -67,6 +67,11 @@ inline bool hasAnyShift(BinaryOp op) {
          op == RotRInt64;
 }
 
+inline bool hasAnyReinterpret(UnaryOp op) {
+  return op == ReinterpretInt32 || op == ReinterpretInt64 ||
+         op == ReinterpretFloat32 || op == ReinterpretFloat64;
+}
+
 // Provide a wasm type and an abstract op and get the concrete one. For example,
 // you can provide i32 and Add and receive the specific opcode for a 32-bit
 // addition, AddInt32. If the op does not exist, it returns Invalid.

--- a/test/lit/passes/optimize-instructions-atomics.wast
+++ b/test/lit/passes/optimize-instructions-atomics.wast
@@ -31,4 +31,24 @@
    )
   )
  )
+
+ ;; CHECK:      (func $dont_simplify_reinterpret_atomic_load_store (param $x i32) (param $y f32)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (f64.reinterpret_i64
+ ;; CHECK-NEXT:    (i64.atomic.load
+ ;; CHECK-NEXT:     (local.get $x)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (i32.atomic.store
+ ;; CHECK-NEXT:   (i32.const 8)
+ ;; CHECK-NEXT:   (i32.reinterpret_f32
+ ;; CHECK-NEXT:    (local.get $y)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $dont_simplify_reinterpret_atomic_load_store (param $x i32) (param $y f32)
+  (drop (f64.reinterpret_i64 (i64.atomic.load (local.get $x))))         ;; skip
+  (i32.atomic.store (i32.const 8) (i32.reinterpret_f32 (local.get $y))) ;; skip
+ )
 )

--- a/test/wasm2js/reinterpret.2asm.js.opt
+++ b/test/wasm2js/reinterpret.2asm.js.opt
@@ -21,14 +21,6 @@
     f64ScratchView[0] = value;
   }
       
-  function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[2] = value;
-  }
-      
-  function wasm2js_scratch_load_f32() {
-    return f32ScratchView[2];
-  }
-      
 function asmFunc(env) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
@@ -45,7 +37,7 @@ function asmFunc(env) {
  var infinity = Infinity;
  function $1($0) {
   $0 = $0 | 0;
-  return ((wasm2js_scratch_store_f32((wasm2js_scratch_store_i32(2, $0), wasm2js_scratch_load_f32())), wasm2js_scratch_load_i32(2)) | 0) == ($0 | 0) | 0;
+  return 1;
  }
  
  function legalstub$2($0, $1_1) {


### PR DESCRIPTION
Fixes #3973

Loads:

f32.reinterpret_i32(i32.load(x))  =>  f32.load(x)
f64.reinterpret_i64(i64.load(x))  =>  f64.load(x)
i32.reinterpret_f32(f32.load(x))  =>  i32.load(x)
i64.reinterpret_f64(f64.load(x))  =>  i64.load(x)

Stores:

f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)

Also optimize reinterprets that are undone:

i32.reinterpret_f32(f32.reinterpret_i32(x))  =>  x
i64.reinterpret_f64(f64.reinterpret_i64(x))  =>  x
f32.reinterpret_i32(i32.reinterpret_f32(x))  =>  x
f64.reinterpret_i64(i64.reinterpret_f64(x))  =>  x